### PR TITLE
fix: use fallback directory when root markers are missing

### DIFF
--- a/lua/java-core/ls/servers/jdtls/init.lua
+++ b/lua/java-core/ls/servers/jdtls/init.lua
@@ -104,6 +104,15 @@ function M.get_root_finder(root_markers)
 		if root then
 			log.debug('root of ' .. file_name .. ' is ' .. root)
 			return root
+		else
+			local fallback_dir = vim.fn.getcwd()
+			log.debug(
+				"couldn't find root of "
+					.. file_name
+					.. ' using fallback dir '
+					.. fallback_dir
+			)
+			return fallback_dir
 		end
 	end
 end


### PR DESCRIPTION
* In case the root markers are missing, use a fallback directory returned by the `vim.fn.getcwd()` function.  After creating any root markers, jdtls recognizes and uses them after a restart.  

 * I think people who just want to try nvim-java with a simple project, are stuck without a fallback directory.