### PR TITLE
fix: update mason API usage for nvim-java compatibility

### DIFF
--- a/lua/java-core/ls/servers/jdtls/init.lua
+++ b/lua/java-core/ls/servers/jdtls/init.lua
@@ -31,7 +31,7 @@ function M.get_config(opts)
 	local jdtls_config = path.join(jdtls_root, 'config')
 	local lombok_path = path.join(lombok_root, 'lombok.jar')
 	local equinox_launcher =
-		path.join(jdtls_root, 'plugins', 'org.eclipse.equinox.launcher.jar')
+			path.join(jdtls_root, 'plugins', 'org.eclipse.equinox.launcher.jar')
 	local plugin_paths = plugins.get_plugin_paths(opts.jdtls_plugins)
 	local base_config = config.get_config()
 
@@ -70,7 +70,7 @@ function M.get_config(opts)
 
 		if jdk:is_installed() then
 			local java_home =
-				vim.fn.glob(path.join(jdk:get_install_path(), '/jdk-17*'))
+					vim.fn.glob(vim.fn.expand('$MASON/packages/openjdk-17/jdk-17*'))
 			local java_bin = path.join(java_home, '/bin')
 
 			base_config.cmd_env = {
@@ -108,9 +108,9 @@ function M.get_root_finder(root_markers)
 			local fallback_dir = vim.fn.getcwd()
 			log.debug(
 				"couldn't find root of "
-					.. file_name
-					.. ' using fallback dir '
-					.. fallback_dir
+				.. file_name
+				.. ' using fallback dir '
+				.. fallback_dir
 			)
 			return fallback_dir
 		end

--- a/lua/java-core/utils/mason.lua
+++ b/lua/java-core/utils/mason.lua
@@ -6,21 +6,25 @@ local M = {}
 ---@param pkg_name string
 ---@return string | nil
 function M.get_pkg_path(pkg_name)
-	return mason_registry.get_package(pkg_name):get_install_path()
+  local mason_data_path = vim.fn.stdpath("data") .. "/mason/packages/" .. pkg_name
+  return mason_data_path
 end
 
----Returns true if the package in installed in mason
+---Returns true if the package is installed in mason
 ---@param pkg_name string
 ---@return boolean
 function M.is_pkg_installed(pkg_name)
-	return mason_registry.get_package(pkg_name):is_installed()
+  local ok, pkg = pcall(mason_registry.get_package, pkg_name)
+  return ok and pkg:is_installed()
 end
 
 ---Returns the shared artifact path for a given package
----@param pkg_name string name of the package to get the path of
----@return string # path to the shared artifact directory of the package
+---@param pkg_name string
+---@return string
 function M.get_shared_path(pkg_name)
-	return vim.fn.glob('$MASON/share/' .. pkg_name)
+  local mason_share_path = vim.fn.stdpath("data") .. "/mason/share/" .. pkg_name
+  return mason_share_path
 end
 
 return M
+


### PR DESCRIPTION
### Summary

This PR updates deprecated Mason APIs (`get_install_path`) used in `nvim-java-core` to work with Mason v2.2.0+.

### Changes

- **Updated**: `init.lua` in `ls/servers/jdtls` to use `vim.fn.expand("$MASON/…")` for finding JDK paths.
- **Updated**: `utils/mason.lua` to replace deprecated Mason API calls with standard path functions (`vim.fn.stdpath`).
- **Handled**: safe usage of `get_package` with `pcall` to avoid crashes when packages are not installed.

### Motivation

Recent versions of `mason.nvim` removed or changed the `get_install_path()` method, breaking integration with `nvim-java`. This patch restores compatibility.

### Testing

Tested with:
- Mason v2.2.0
---
